### PR TITLE
builds clean checkout, document USE_LOCAL_CC65, fix make clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,14 @@
 
-ifeq ($(USE_LOCAL_CC65),"")
-CC65=	cc65/bin/cc65
-CL65=	cc65/bin/cl65
+ifdef USE_LOCAL_CC65
+	# use locally installed binary (requires cc65 to be in the $PATH)
+	CC65=	cc65
+	CL65=	cl65
 else
-CC65=	cc65
-CL65=	cl65
+	# use the binary built from the submodule
+	CC65=	cc65/bin/cc65
+	CL65=	cc65/bin/cl65
 endif
+
 #COPTS=	-t c64 -O -Or -Oi -Os --cpu 65c02 -Icc65/include
 COPTS=	-t c64 -Os --cpu 65c02 -Icc65/include
 LOPTS=	--asm-include-dir cc65/asminc --cfg-path cc65/cfg --lib-path cc65/lib
@@ -77,12 +80,12 @@ install:	all
 
 $(CC65):
 	$(warning ======== Making: $@)
-ifeq ($(USE_LOCAL_CC65),"")
+ifdef $(USE_LOCAL_CC65)
+	@echo "Using local installed CC65."
+else
 	git submodule init
 	git submodule update
 	( cd cc65 && make -j 8 )
-else
-	@echo "Using local installed CC65."
 endif
 
 ascii8x8.bin: ascii00-7f.png pngprepare

--- a/Makefile
+++ b/Makefile
@@ -133,7 +133,16 @@ tools/thumbnail-surround-formatter:
 
 
 clean:
-	rm -f $(FILES)
+	rm -f $(FILES) *.o \
+	audiomix.s \
+	freeze_*.s \
+	frozen_memory.s \
+	fdisk_*.s \
+	freezer.s sprited.s \
+	*.map \
+	ascii.h ascii8x8.bin asciih \
+	pngprepare \
+	tools/thumbnail-surround-formatter
 
 cleangen:
 	rm ascii8x8.bin

--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,7 @@ HEADERS=	Makefile \
 DATAFILES=	ascii8x8.bin
 
 %.s:	%.c $(HEADERS) $(DATAFILES) $(CC65)
+	$(warning ======== Making: $@)
 	$(CC65) $(COPTS) -o $@ $<
 
 all:	$(FILES)
@@ -75,6 +76,7 @@ install:	all
 	m65ftp < install.mftp
 
 $(CC65):
+	$(warning ======== Making: $@)
 ifeq ($(USE_LOCAL_CC65),"")
 	git submodule init
 	git submodule update
@@ -84,35 +86,46 @@ else
 endif
 
 ascii8x8.bin: ascii00-7f.png pngprepare
+	$(warning ======== Making: $@)
 	./pngprepare charrom ascii00-7f.png ascii8x8.bin
 
 asciih:	asciih.c
+	$(warning ======== Making: $@)
 	$(CC) -o asciih asciih.c
 ascii.h:	asciih
+	$(warning ======== Making: $@)
 	./asciih
 
 pngprepare:	pngprepare.c
+	$(warning ======== Making: $@)
 	$(CC) -I/usr/local/include -L/usr/local/lib -o pngprepare pngprepare.c -lpng
 
 FREEZER.M65:	$(ASSFILES) $(DATAFILES) $(CC65)
+	$(warning ======== Making: $@)
 	$(CL65) $(COPTS) $(LOPTS) -vm -m freezer.map -o FREEZER.M65 $(ASSFILES)
 
 AUDIOMIX.M65:	$(AMASSFILES) $(DATAFILES) $(CC65)
+	$(warning ======== Making: $@)
 	$(CL65) $(COPTS) $(LOPTS) -vm -m audiomix.map -o AUDIOMIX.M65 $(AMASSFILES)
 
 SPRITED.M65:	$(SEASSFILES) $(DATAFILES) $(CC65)
+	$(warning ======== Making: $@)
 	$(CL65) $(COPTS) $(LOPTS) -vm -m sprited.map -o SPRITED.M65 $(SEASSFILES)
 
 C65THUMB.M65:	assets/thumbnail-surround-c65.png tools/thumbnail-surround-formatter
+	$(warning ======== Making: $@)
 	tools/thumbnail-surround-formatter assets/thumbnail-surround-c65.png C65THUMB.M65 
 
 C64THUMB.M65:	assets/thumbnail-surround-c64.png tools/thumbnail-surround-formatter
+	$(warning ======== Making: $@)
 	tools/thumbnail-surround-formatter assets/thumbnail-surround-c64.png C64THUMB.M65 
 
 GUSTHUMB.M65:	assets/thumbnail-surround-gus.png tools/thumbnail-surround-formatter
+	$(warning ======== Making: $@)
 	tools/thumbnail-surround-formatter assets/thumbnail-surround-gus.png GUSTHUMB.M65 
 
 tools/thumbnail-surround-formatter:
+	$(warning ======== Making: $@)
 	gcc -o tools/thumbnail-surround-formatter tools/thumbnail-surround-formatter.c -lpng
 
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Freeze menu and associated integrated utilities for the MEGA65.
+Freeze menu and associated integrated utilities for the MEGA65 (http://github.com/MEGA65).
 
 This program should be installed in the root directory of the MEGA65's SD card
 for the MEGA65 to function correctly, as much of the interaction with a MEGA65
@@ -6,3 +6,18 @@ is via the freeze menu, e.g., to mount disk images, swap loaded program etc.
 
 This program was started by forking the MEGA65 FDISK/FORMAT utility, since it
 has a bunch of the routines we need already in it.
+
+## Prerequisites
+* need something for ```pngprepare```, -> ```sudo apt install libpng12-dev```
+* the 'cc65' toolchain is required, and by default this is taken care of in the Makefile.
+Alternatively, you can supply your pre-built ```cc65``` binaries (see below at "CI").
+
+## Building
+* ``make`` will build (including init/update/build of submodule ``./cc65``)
+
+## Continuous Integration (CI)
+For CI building, you may not want to build the cc65-submodule,
+but rather use a locally installed binary instead.
+
+In that case, build with:
+```make USE_LOCAL_CC65=1```


### PR DESCRIPTION
same update to that of the mega65-core/fdisk-submodule

then yes, after this patch is approved, the mega65-core will need update (I can do)