### PR TITLE
Release V0.6 

### DIFF
--- a/freeze_sprited.c
+++ b/freeze_sprited.c
@@ -23,7 +23,12 @@
 
     v0.5        Uses conio for proper initialization and some of its
                 new features.  Color selection with MEGA/CTRL keys.
+
+    v0.6        Multicolor and 16-color sprite support.
+                
  */
+
+#define TEST_SPRITES
 
 #include <cc65.h>
 #include "../mega65-libc/cc65/include/conio.h"
@@ -36,30 +41,30 @@
 
 extern int errno;
 
-#define VIC_BASE 0xD000UL
-#define REG_HOTREG (VIC_BASE + 0x5D)
-#define REG_SPRPTR_B0 (PEEK(VIC_BASE + 0x6C))
-#define REG_SPRPTR_B1 (PEEK(VIC_BASE + 0x6D))
-#define REG_SPRPTR_B2 (PEEK(VIC_BASE + 0x6E))
-#define REG_SCREEN_RAM_ADDRESS 0x8000
-#define REG_SCREEN_BASE_B0 (VIC_BASE + 0x60)
-#define REG_SCREEN_BASE_B1 (VIC_BASE + 0x61)
-#define REG_SCREEN_BASE_B2 (VIC_BASE + 0x62)
-#define REG_SCREEN_BASE_B3 (VIC_BASE + 0x63) // Bits 0..3
-#define IS_SPR_MULTICOLOR(n) ((PEEK(VIC_BASE + 0x1C)) & (1 << (n)))
-#define IS_SPR_16COL(n) ((PEEK(VIC_BASE + 0x6B)) & (1 << (n)))
-#define SPRITE_POINTER_ADDR (((long)REG_SPRPTR_B0) | ((long)REG_SPRPTR_B1 << 8) | ((long)REG_SPRPTR_B2 << 16))
-#define TRUE 1
-#define FALSE 0
-#define SPRITE_MAX_COUNT 8
-#define DEFAULT_BORDER_COLOR 6
-#define DEFAULT_SCREEN_COLOR 6
-#define DEFAULT_BACK_COLOR 11
-#define DEFAULT_FORE_COLOR 1
-#define DEFAULT_MULTI1_COLOR 3
-#define DEFAULT_MULTI2_COLOR 4
-#define TRANS_CHARACTER 230
-#define TOOLBOX_COLUMN  65
+#define VIC_BASE                    0xD000UL
+#define REG_HOTREG                  (VIC_BASE + 0x5D)
+#define REG_SPRPTR_B0               (PEEK(VIC_BASE + 0x6C))
+#define REG_SPRPTR_B1               (PEEK(VIC_BASE + 0x6D))
+#define REG_SPRPTR_B2               (PEEK(VIC_BASE + 0x6E))
+#define REG_SCREEN_RAM_ADDRESS      0x8000
+#define REG_SCREEN_BASE_B0          (VIC_BASE + 0x60)
+#define REG_SCREEN_BASE_B1          (VIC_BASE + 0x61)
+#define REG_SCREEN_BASE_B2          (VIC_BASE + 0x62)
+#define REG_SCREEN_BASE_B3          (VIC_BASE + 0x63) // Bits 0..3
+#define IS_SPR_MULTICOLOR(n)        ((PEEK(VIC_BASE + 0x1C)) & (1 << (n)))
+#define IS_SPR_16COL(n)             ((PEEK(VIC_BASE + 0x6B)) & (1 << (n)))
+#define SPRITE_POINTER_ADDR         (((long)REG_SPRPTR_B0) | ((long)REG_SPRPTR_B1 << 8) | ((long)REG_SPRPTR_B2 << 16))
+#define TRUE                        1
+#define FALSE                       0
+#define SPRITE_MAX_COUNT            8
+#define DEFAULT_BORDER_COLOR        6
+#define DEFAULT_SCREEN_COLOR        6
+#define DEFAULT_BACK_COLOR          11
+#define DEFAULT_FORE_COLOR          1
+#define DEFAULT_MULTI1_COLOR        3
+#define DEFAULT_MULTI2_COLOR        4
+#define TRANS_CHARACTER             230
+#define TOOLBOX_COLUMN              65
 
 // Index into color array
 #define COLOR_BACK 0
@@ -113,6 +118,8 @@ unsigned char sprite_pointer[63]={
   0x00, 0x70, 0x00, 0x00, 0x70, 0x00, 0x00, 0x38, 0x00, 0x00, 0x38, 0x00, 0x00, 0x00, 0x00
 };
 
+#ifdef TEST_SPRITES
+
     // Sprite 1 to test Multicolor
 
     unsigned char test_mc [64] ={
@@ -124,6 +131,19 @@ unsigned char sprite_pointer[63]={
     0xda,0xa0,0x03,0x6a,0x80,0x01,0xa6,0x80,
     0x00,0x7a,0x00,0x00,0x28,0x00,0x00,0x00,
     0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x83};
+
+    // Sprite 2 to test 16-color
+
+    unsigned char test_16 [64]={
+    0x00,0x01,0x02,0x03,0x04,0x05,0x06,0x07,
+    0x08,0x09,0x0A,0x0B,0x0C,0x0D,0x0E,0x0F,
+    0x10,0x11,0x12,0x13,0x14,0x15,0x16,0x17,
+    0x18,0x19,0x1A,0x1B,0x1C,0x1D,0x1E,0x1F,
+    0x20,0x21,0x22,0x23,0x24,0x25,0x26,0x27,
+    0x28,0x29,0x2A,0x2B,0x2C,0x2D,0x2E,0x2F,
+    0x30,0x31,0x32,0x33,0x34,0x35,0x36,0x37,
+    0x48,0x19,0x1A,0x1B,0x1C,0x1D,0x1E,0x1F};
+#endif 
 
 static void Initialize()
 {
@@ -137,6 +157,8 @@ static void Initialize()
     POKE(0xD015,1);
     POKE(0x07F8,0x380/64);
     POKE(0x07F9,(0x380+64)/64);
+    POKE(0x07FA,(0x380+128)/64);
+
     POKE(0xD000,100);
     POKE(0xD001,100);
     POKE(0xD027,7);
@@ -144,13 +166,18 @@ static void Initialize()
     POKE(0xD06D,0x07);
     POKE(0xD06E,0x00);
 
-
     POKE(53276UL, 2);
-    lcopy((long)test_mc,0x380+64,64);
 
     setscreenaddr(0x8000);
     setscreensize(80,25);
     setextendedattrib(1);
+
+#ifdef TEST_SPRITES
+    POKE(VIC_BASE + 0x6B, 4);
+
+    lcopy((long)test_mc,0x380+64,64);
+    lcopy((long)test_16,0x380+64+64,64);
+#endif
 
     g_state.color[COLOR_BACK] = DEFAULT_BACK_COLOR;
     g_state.color[COLOR_FORE] = DEFAULT_FORE_COLOR;
@@ -199,7 +226,18 @@ static void DrawMonoCell(BYTE x, BYTE y)
 
 static void Draw16ColorCell(BYTE x, BYTE y)
 {
-    
+    register BYTE cell = 0;
+    const long byteAddr = (g_state.spriteDataAddr + (y * 3)) + (x / 2);
+    const BYTE p = lpeek(byteAddr) & ( 0xF >> (x % 2));
+
+    revers(1);
+    gotoxy(g_state.canvasLeftX + (x * g_state.cellsPerPixel), y + 2);
+    for (cell = 0; cell < g_state.cellsPerPixel; ++cell)
+    {
+        textcolor(p & 0xF);
+        cputc(p ? ' ' : TRANS_CHARACTER);
+    }
+    revers(0);
 }
 
 static void DrawMulticolorCell(BYTE x, BYTE y)
@@ -279,9 +317,9 @@ void UpdateSpriteParameters(void)
     {
         g_state.drawCellFn = Draw16ColorCell;
         g_state.togglePixelFn = TogglePixel16Color;
-        g_state.spriteSizeBytes = 168;
         g_state.spriteColorMode = SPR_COLOR_MODE_16COLOR;
-        g_state.spriteWidth = 16;
+        g_state.spriteWidth = 6;
+        g_state.cellsPerPixel = 4;
     }
     else if (IS_SPR_MULTICOLOR(g_state.spriteNumber))
     {
@@ -301,6 +339,16 @@ void UpdateSpriteParameters(void)
 
     g_state.canvasLeftX =  (TOOLBOX_COLUMN / 2) - (g_state.spriteWidth * g_state.cellsPerPixel / 2);
 
+}
+
+static void EraseCanvasSpace()
+{
+    RECT rc;
+    rc.top = 2;
+    rc.left = 0;
+    rc.right = TOOLBOX_COLUMN-1;
+    rc.bottom = 23;
+    fillrect(&rc, ' ', 1);
 }
 
 static void DrawCanvas()
@@ -330,7 +378,7 @@ static void DrawToolbox()
     cputs("sprite ");
     cputdec(g_state.spriteNumber, 0, 0);
     cputs(g_state.spriteColorMode == SPR_COLOR_MODE_MONOCHROME ? " mono    " : 
-        (g_state.spriteColorMode == SPR_COLOR_MODE_MULTICOLOR ? " multi   " : " 16 color"));
+        (g_state.spriteColorMode == SPR_COLOR_MODE_MULTICOLOR ? " multi   " : " 16-col"));
     gotoxy(TOOLBOX_COLUMN, 3);
     textcolor(3);
     cputhex(g_state.spriteDataAddr, 7);
@@ -388,7 +436,7 @@ static void DrawToolbox()
 
 static BYTE SaveRawData(const BYTE name[16], char deviceNumber)
 {
-    return cbm_save(name, deviceNumber, g_state.spriteDataAddr, g_state.spriteSizeBytes);
+    //return cbm_save(name, deviceNumber, g_state.spriteDataAddr, g_state.spriteSizeBytes);
 }
 
 static BYTE LoadRawData(const BYTE name[16])
@@ -660,6 +708,7 @@ static void MainLoop()
                 g_state.spriteNumber = 0;
 
             UpdateSpriteParameters();
+            EraseCanvasSpace();
             redrawCanvas = redrawTools = TRUE;
             break;
 
@@ -668,6 +717,7 @@ static void MainLoop()
                 g_state.spriteNumber = SPRITE_MAX_COUNT - 1;
 
             UpdateSpriteParameters();
+            EraseCanvasSpace();
             redrawCanvas = redrawTools = TRUE;
             break;
 
@@ -774,8 +824,6 @@ static void MainLoop()
 void do_sprite_editor()
 {
     Initialize();
-    //cprintf("{rvson}{yel}   formatted-print    {d}{red} {d}{cyan} {d}{grn} {wht}{blon}blink{bloff}{rvsoff} {lgrn}{u}{ulon}underline{uloff}");
-    //cgetc();    
     DrawScreen();
     MainLoop();
     DoExit();


### PR DESCRIPTION
V0.6

This updated Sprite Editor uses proper initialization from CONIO instead of manually poking, clearing key buffer, etc. Also some of the new conio.h features such as Cprintf are used for output, compact code and some kind of demostration for users.
Also CTRL and MEGA is used now for color selection.
Additional features include:

- FIX: Screen moved to $12000. 
-  Multicolor and 16-color sprite support. 
-  New color selection UI.
- Change sprite type on-the-fly.with * key.
- Clear sprite key.

Thanks.