### PR TITLE
Sprite Editor v0.8

### DIFF
--- a/freeze_sprited.c
+++ b/freeze_sprited.c
@@ -124,9 +124,9 @@ typedef enum tagSPR_COLOR_MODE
 typedef enum tagDRAWING_TOOL
 {
     DRAWING_TOOL_PIXEL = 0,
+    DRAWING_TOOL_LINE,
     DRAWING_TOOL_BOX,
     DRAWING_TOOL_FILLEDBOX,
-    DRAWING_TOOL_LINE,
     DRAWING_TOOL_CIRCLE,
     DRAWING_TOOL_FILLED_CIRCLE,
 } DRAWING_TOOL;
@@ -235,18 +235,18 @@ static const BYTE chsetToolbox[] = {
 
     // Pixel tool 
     0,0,255,128,128,128,128,129, 0,0,255,1,1,1,1,129,
+
+    // Line tool
+    0,0,255,128,128,176,140,131, 0,0,255,1,1,1,1,1,
     
     // Box tool
     0,0,255,128,128,159,144,144,  0,0,255,1,1,249,9,9,
 
-    // Circle tool
-    0,0,255,128,128,131,132,136, 0,0,255,1,1,193,33,17,
-
-    // Line tool
-    0,0,255,128,128,176,140,131, 0,0,255,1,1,1,1,1,
-
     // Filled-box tool
     0,0,255,128,128,143,143,143, 0,0,255,1,1,241,241,241,
+
+    // Circle tool
+    0,0,255,128,128,131,132,136, 0,0,255,1,1,193,33,17,
 
     // Filled-circle tool
     0,0,255,128,128,129,135,143, 0,0,255,1,1,129,225,241,
@@ -256,17 +256,17 @@ static const BYTE chsetToolbox[] = {
      // Pixel tool 
     129,128,128,128,128,255,63,0, 129,1,1,1,1,255,255,0,
     
-    // Box tool
-    144,144,159,128,128,255,255,0,  9,9,249,1,1,255,255,0,
-
-    // Circle tool
-     136,132,131,128,128,255,255,0, 17,33,193,1,1,255,255,0,
-
     // Line tool
     128,128,128,128,128,255,255,0, 193,49,13,1,1,255,255,0,
 
+    // Box tool
+    144,144,159,128,128,255,255,0,  9,9,249,1,1,255,255,0,
+    
     // Filled-box tool
     143,143,143,128,128,255,255,0, 241,241,241,1,1,255,255,0,
+
+    // Circle tool
+     136,132,131,128,128,255,255,0, 17,33,193,1,1,255,255,0,
 
     // Filled-circle tool
     143,135,129,128,128,255,255,0, 241,225,129,1,1,255,255,0
@@ -381,7 +381,7 @@ static void DrawLine(BOOL bPreview)
 static void DrawBox(BOOL bPreview)
 {
     RECT rc;
-    register BYTE x, y;
+    register BYTE x, y, i;
     void(*pfun)(BYTE,BYTE) = bPreview ? DrawShapeChar : g_state.paintCellFn;
     SetEffectiveToolRect(&rc);
 
@@ -389,6 +389,13 @@ static void DrawBox(BOOL bPreview)
     while (x <= rc.right)
     {
         pfun(x,g_state.cursorY);
+        if (g_state.fillShape) 
+        {
+            for(i = rc.top+1 ; i < rc.bottom ; ++i) 
+            {
+                pfun(x,i);
+            }
+        }
         pfun(x++,g_state.toolOrgY);
     }
 
@@ -406,11 +413,16 @@ void SetDrawTool(DRAWING_TOOL dt)
     switch(dt)
     {
         case DRAWING_TOOL_BOX:   
-        case DRAWING_TOOL_FILLEDBOX:
+            g_state.fillShape = 0;
             g_state.drawShapeFn = DrawBox; 
             break;
-
-        case DRAWING_TOOL_LINE:  g_state.drawShapeFn = DrawLine; break;
+        case DRAWING_TOOL_FILLEDBOX:
+            g_state.fillShape = 1;
+            g_state.drawShapeFn = DrawBox; 
+            break;
+        case DRAWING_TOOL_LINE:  
+            g_state.drawShapeFn = DrawLine; 
+            break;
     }
 }
 
@@ -766,46 +778,6 @@ static void DrawSidebar()
     DrawCoordinates();
     DrawToolbox();
     DrawColorSelector();
-    //textcolor(14);
-
-
-    // cputsxy(TOOLBOX_COLUMN, 10, ", . sel sprite");
-    // cputsxy(TOOLBOX_COLUMN, 11, "spc draw");
-    // if (g_state.spriteColorMode == SPR_COLOR_MODE_MULTICOLOR)
-    // {
-    //     cputsxy(TOOLBOX_COLUMN, 12, "h   sel fgcolor");
-    //     cputsxy(TOOLBOX_COLUMN, 13, "j   sel bkcolor");
-    //     cputsxy(TOOLBOX_COLUMN, 14, "k   sel color1 ");
-    //     cputsxy(TOOLBOX_COLUMN, 15, "l   sel color2 ");
-    // }
-    // else if (g_state.spriteColorMode == SPR_COLOR_MODE_MONOCHROME)
-    // {
-    //     cputsxy(TOOLBOX_COLUMN, 12, "j   sel fgcolor");
-    //     cputsxy(TOOLBOX_COLUMN, 13, "k   sel bkcolor");
-    //     cputsxy(TOOLBOX_COLUMN, 14, "               ");
-    //     cputsxy(TOOLBOX_COLUMN, 15, "               ");
-    // }
-    // else 
-    // {
-    //     cputsxy(TOOLBOX_COLUMN, 12, "               ");
-    //     cputsxy(TOOLBOX_COLUMN, 13, "               ");
-    //     cputsxy(TOOLBOX_COLUMN, 14, "               ");
-    //     cputsxy(TOOLBOX_COLUMN, 15, "               ");
-    // }
-    // cputsxy(TOOLBOX_COLUMN, 16, "*   change type");
-    // cputsxy(TOOLBOX_COLUMN, 17, "s   save");
-    // cputsxy(TOOLBOX_COLUMN, 18, "l   load");
-    // cputsxy(TOOLBOX_COLUMN, 20, "c   clear");
-    // cputsxy(TOOLBOX_COLUMN, 19, "f1  help/info");
-    // cputsxy(TOOLBOX_COLUMN, 21, "f3  exit");
-
-    // for(i = 10; i <= 21; ++i)
-    // {
-    //     cellcolor(SIDEBAR_COLUMN,   i, COLOUR_GREY3);
-    //     cellcolor(SIDEBAR_COLUMN+1, i, COLOUR_GREY3);
-    //     cellcolor(SIDEBAR_COLUMN+2, i, COLOUR_GREY3);
-    // }
-    
     g_state.redrawSideBarFlags = REDRAW_SB_NONE;
 }
 
@@ -1148,6 +1120,11 @@ static void MainLoop()
 
         case 120: // x = draw box
             SetDrawTool(DRAWING_TOOL_BOX);
+            g_state.redrawSideBarFlags = REDRAW_SB_TOOLS;
+            break;
+
+        case 88: 
+            SetDrawTool(DRAWING_TOOL_FILLEDBOX);
             g_state.redrawSideBarFlags = REDRAW_SB_TOOLS;
             break;
 

--- a/freeze_sprited.c
+++ b/freeze_sprited.c
@@ -374,7 +374,29 @@ static void DrawLine(BOOL bPreview)
     } 
     else    // Bresenham- algorithm.
     {
+        const signed char dx = rc.right - rc.left;
+        const signed char dy = -(rc.bottom - rc.top);
+        BYTE x = g_state.toolOrgX, y = g_state.toolOrgY;
+        signed char e = dx + dy;
+        signed char e2 = 0;
+        signed char sx = g_state.cursorX > g_state.toolOrgX ? 1 : -1;
+        signed char sy = g_state.cursorY > g_state.toolOrgY ? 1 : -1;
 
+        while (x != g_state.cursorX && y != g_state.cursorY)
+        {
+            pfun(x,y);
+            e2 = e * 2;
+            if (e2 >= dy)
+            { 
+                e += dy; 
+                x += sx; 
+            }
+            if (e2 <= dx) 
+            { 
+                e += dx; 
+                y += sy; 
+            }
+        }
     }
 }
 

--- a/freeze_sprited.c
+++ b/freeze_sprited.c
@@ -45,7 +45,7 @@
       only the needed area.
  */
 
-#define TEST_SPRITES
+//#define TEST_SPRITES
 
 #include <cc65.h>
 #include "../mega65-libc/cc65/include/conio.h"
@@ -313,9 +313,14 @@ static void Initialize()
     lcopy((long)sprite_pointer,0x380,63);
     POKE(0xD015,1);
     POKE(0x07F8,0x380/64);
-    POKE(0x07F9,(0x380+64)/64);
-    POKE(0x07FA,(0x380+128)/64);
-
+    // POKE(0x07F9,(0x380+64)/64);
+    // POKE(0x07FA,(0x380+64*2)/64);
+    // POKE(0x07FB,(0x380+64*3)/64);
+    // POKE(0x07FC,(0x380+64*4)/64);
+    // POKE(0x07FD,(0x380+64*5)/64);
+    // POKE(0x07FE,(0x380+64*6)/64);
+    // POKE(0x07FF,(0x380+64*7)/64);
+    
     POKE(0xD000,100);
     POKE(0xD001,100);
     POKE(0xD027,7);
@@ -426,7 +431,35 @@ static void DrawLine(BOOL bPreview)
 
 static void DrawCircle(BOOL bPreview)
 {
-    
+    // RECT rc;
+    // void (*pfun)(BYTE, BYTE) = bPreview ? DrawShapeChar : g_state.paintCellFn;
+    // SetEffectiveToolRect(&rc);
+
+    // const signed char dx = rc.right - rc.left;
+    // const signed char dy = -(rc.bottom - rc.top);
+    // BYTE x = g_state.toolOrgX, y = g_state.toolOrgY;
+    // signed char e = dx + dy;
+    // signed char e2 = 0;
+    // signed char sx = g_state.cursorX > g_state.toolOrgX ? 1 : -1;
+    // signed char sy = g_state.cursorY > g_state.toolOrgY ? 1 : -1;
+
+    // for (;;)
+    // {
+    //     pfun(x, y);
+    //     if (x == g_state.cursorX && y == g_state.cursorY)
+    //         break;
+    //     e2 = e * 2;
+    //     if (e2 >= dy)
+    //     {
+    //         e += dy;
+    //         x += sx;
+    //     }
+    //     if (e2 <= dx)
+    //     {
+    //         e += dx;
+    //         y += sy;
+    //     }
+    // }
 }
 
 static void DrawBox(BOOL bPreview)
@@ -962,9 +995,10 @@ static void TestMode()
     }
     
     POKE(0xD010UL, 0);
+    POKE(0xD015UL, 1 << g_testModeParams.animCurFrame );
     POKE(0xD01D, g_testModeParams.horizExpand);
     POKE(0xD017, g_testModeParams.vertExpand);
-
+    
     DrawHeader();
 
     while (!exit)
@@ -1351,6 +1385,7 @@ static void MainLoop()
             SetDrawTool(DRAWING_TOOL_PIXEL);
             g_state.redrawSideBarFlags = REDRAW_SB_TOOLS;
             SetRedrawFullCanvas();
+            g_state.toolActive = 0;
             break;
 
         case 120: // x = draw box

--- a/freeze_sprited.c
+++ b/freeze_sprited.c
@@ -35,6 +35,7 @@
                 Supports 16-bit sprite data pointers (SPRPTR16).
                 Honours VIC-II Bank bits ($DD00) if SPRPTR16 is OFF.
                 Honours VIC color registers.
+                Supports extended width sprites (SPRX64EN)
                 16-color sprite uses 64-bit implicit width.
                 Drawing tools: pixel, box, circle ,lines.
                 Sprite Test Mode.


### PR DESCRIPTION
- 80x50 screen mode option, new UI, redraw optimizations.
- Redesigned key scheme.
- Supports 16-bit sprite data pointers (SPRPTR16).
- Honours VIC-II Bank bits ($DD00) if SPRPTR16 is OFF.
- Honours VIC color registers.
- 16-color sprite uses 64-bit implicit width.
- Supports extended width sprites (SPRX64EN)
- Drawing tools: pixel, box, circle ,lines.
- Sprite Test Mode.