### PR TITLE
Remove infinite loops when attempting to clear "use real drive" flags

### DIFF
--- a/freeze_diskchooser.c
+++ b/freeze_diskchooser.c
@@ -468,6 +468,16 @@ char* freeze_select_disk_image(unsigned char drive_id)
           break;
         }
 
+      // First, clear flags for the F011 image
+      if (drive_id == 0) {
+        // Clear flags for drive 0
+        lpoke(0xffd368bL, lpeek(0xffd368bL) & 0xb8);
+      }
+      else if (drive_id == 1) {
+        // Clear flags for drive 1
+        lpoke(0xffd368bL, lpeek(0xffd368bL) & 0x47);
+      }
+
       // Try to mount it, with border black while working
       POKE(0xD020U, 0);
       if (disk_name_return[0] == '/') {

--- a/freeze_diskchooser.c
+++ b/freeze_diskchooser.c
@@ -468,25 +468,6 @@ char* freeze_select_disk_image(unsigned char drive_id)
           break;
         }
 
-      // First, clear flags for the F011 image
-      if (drive_id == 0) {
-        // Clear flags for drive 0
-        lpoke(0xffd368bL, lpeek(0xffd368bL) & 0xb8);
-
-        // there seem to be an issue reliably using lpoke/lpeek here
-        // so for now we repeat to ensure we have what we want
-        while (lpeek(0xffd36a1L) & 1) {
-          lpoke(0xffd36a1L, lpeek(0xffd36a1L) & 0xfe);
-        }
-      }
-      else if (drive_id == 1) {
-        // Clear flags for drive 1
-        lpoke(0xffd368bL, lpeek(0xffd368bL) & 0x47);
-        while (lpeek(0xffd36a1L) & 4) {
-          lpoke(0xffd36a1L, lpeek(0xffd36a1L) & 0xfb);
-        }
-      }
-
       // Try to mount it, with border black while working
       POKE(0xD020U, 0);
       if (disk_name_return[0] == '/') {


### PR DESCRIPTION
Must be in hypervisor mode to clear the use real floppy flags.  So this will not work and will hang the system.

They sometimes appear to work due to a hypervisor trap having earlier set the flags to zero (to show a .d81 listing).

There is a side effect to this change: If the internal disk is enabled and "No Disk" is selected without previewing or selecting a d81, the internal drive will still be active.  **The hypervisor needs to clear these two bits before launching the freezer (according to Paul)**.