### PR TITLE
Fix chargen area before thumb frame loaded at startup

### DIFF
--- a/freezer.c
+++ b/freezer.c
@@ -827,9 +827,11 @@ int main(int argc, char** argv)
 
   setup_menu_screen();
   predraw_freeze_menu();
+  //chargen fix needs happen before the thumbnail frame is loaded as it clobbers
+  //the thumbnail frame data.
+  fix_chargen_area(CHARGEN_FIXMEM | CHARGEN_NOCHECK);
   draw_freeze_menu(UPDATE_ALL);
 
-  fix_chargen_area(CHARGEN_FIXMEM | CHARGEN_NOCHECK);
 
   // Flush input buffer
   while (PEEK(0xD610U))


### PR DESCRIPTION
`fix_chargen_area` loads the ROM which overwrites the area into which the thumb frame data is loaded.  `draw_freeze_menu` needs to be called afterward.