### PR TITLE
Fix typo causing crashes when changing frequency

### DIFF
--- a/freezer.c
+++ b/freezer.c
@@ -170,7 +170,7 @@ unsigned char next_cpu_speed(void)
     break;
   case 3:
     // Make it 40MHz
-    freeze_poke(0xffd3030L, 0);
+    freeze_poke(0xffd0030L, 0);
     freeze_poke(0xffd3031L, freeze_peek(0xffd3031L) & 0xbf);
     freeze_poke(0xffd3054L, freeze_peek(0xffd3054L) | 0x40);
     // freeze_poke(0xffd367dL, freeze_peek(0xffd367dL) | 0x10);
@@ -178,7 +178,7 @@ unsigned char next_cpu_speed(void)
   case 40:
   default:
     // Make it 1MHz
-    freeze_poke(0xffd3030L, 0);
+    freeze_poke(0xffd0030L, 0);
     freeze_poke(0xffd3031L, freeze_peek(0xffd3031L) & 0xbf);
     freeze_poke(0xffd3054L, freeze_peek(0xffd3054L) & 0xbf);
     // we clear this, but we don't set it again


### PR DESCRIPTION
The crashes are most reproducible when doing disk operations (d81, or IEC) after changing frequency in the freezer using `F` command).

1. Open freezer
2. If nothing mounted on disk 8, Press `0` and select d81
3. Use `F` to change to 1Mhz
4. `F3` to exit
5. `DIR` and it should crash here.  Although I've seen crashes just exiting the freezer too.

Let me know if you want an issue created to tie to this.