### PR TITLE
Make mega65-libc a submodule; cosmetic updates to SpritEd

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,8 @@
 [submodule "cc65"]
 	path = cc65
 	url = https://github.com/cc65/cc65
+	ignore = dirty
+[submodule "mega65-libc"]
+	path = mega65-libc
+	url = https://github.com/MEGA65/mega65-libc.git
+	ignore = dirty

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ else
 endif
 
 #COPTS=	-t c64 -O -Or -Oi -Os --cpu 65c02 -Icc65/include
-COPTS=	-t c64 -Os --cpu 65c02 -Icc65/include
+COPTS=	-t c64 -Os --cpu 65c02 -I mega65-libc/include
 LOPTS=	--asm-include-dir cc65/asminc --cfg-path cc65/cfg --lib-path cc65/lib
 
 FILES=		FREEZER.M65 \
@@ -110,8 +110,8 @@ MIASSFILES=	megainfo.s \
 		infohelper.s \
 		freezer_common.s
 
-LIBCASSFILES=	../mega65-libc/cc65/src/conio.s \
-		../mega65-libc/cc65/src/mouse.s
+LIBCASSFILES=	./mega65-libc/src/conio.s \
+		./mega65-libc/src/mouse.s
 
 HEADERS=	Makefile \
 		freezer.h \

--- a/freeze_sprited.c
+++ b/freeze_sprited.c
@@ -1105,9 +1105,9 @@ static void ShowHelp()
   // clang-format off
   const char* fileKeys[] = {
     "  file / txfer     ",
-    "load             f5",
-    "save raw       f7,r",
-    "save basic     f7,b",
+    "(not impl)       f5", // load
+    "(not impl)     f7,r", // save raw
+    "(not impl)     f7,b", // save basic
     "fetch slot       f9",
     "store slot      f11",
     "exit             f3",
@@ -1119,8 +1119,8 @@ static void ShowHelp()
     "line              l",
     "box               x",
     "filled box      s-x",
-    "not implemented   o",
-    "not implemented s-o",
+    "(not impl)        o", // circle
+    "(not impl)      s-o", // filled circle
   };
 
   const char* colorKeys[] = {
@@ -1143,16 +1143,16 @@ static void ShowHelp()
     "change type       *",
     "toggle h-expand   h",
     "toggle v-expand   v",
-    "toggle x-width    \x1e",
+    "(not impl)        \x1e", // toggle x-width
     "copy sprite  ctrl+c",
-    "horz flip    ctrl+h",
-    "vert flip    ctrl+v",
+    "(not impl)   ctrl+h", // horz flip
+    "(not impl)   ctrl+v", // vert flip
   };
 
   const char* displayKeys[] = {
     "     display       ",
     "aspect ratio  alt+r",
-    "25/50-line    alt+d",
+    "(not impl)    alt+d", // 25/50-line
   };
 
   const char* tipsNtricks[] = {
@@ -1432,16 +1432,17 @@ static void MainLoop()
       break;
 
     case '@': // 94: // Up-arrow
-      POKE(LOCAL_REG_SPRX64EN, PEEK(LOCAL_REG_SPRX64EN) ^ (1 << PREVIEW_SPRITE_NUM));
-      FREEZE_POKE(REG_SPRX64EN, FREEZE_PEEK(REG_SPRX64EN) ^ (1 << g_state.spriteNumber));
-      g_state.redrawFlags = REDRAW_SB_ALL;
-      g_state.updateCursorXFn = PEEK(LOCAL_REG_SPRX64EN) & (1 << PREVIEW_SPRITE_NUM) ? UpdateCursorXMSB : UpdateCursorX;
-      UpdateAndFullRedraw(FALSE);
-      UpdateSpritePreview();
+      // TODO: Disabled until we can fix it; issue #77
+      // POKE(LOCAL_REG_SPRX64EN, PEEK(LOCAL_REG_SPRX64EN) ^ (1 << PREVIEW_SPRITE_NUM));
+      // FREEZE_POKE(REG_SPRX64EN, FREEZE_PEEK(REG_SPRX64EN) ^ (1 << g_state.spriteNumber));
+      // g_state.redrawFlags = REDRAW_SB_ALL;
+      // g_state.updateCursorXFn = PEEK(LOCAL_REG_SPRX64EN) & (1 << PREVIEW_SPRITE_NUM) ? UpdateCursorXMSB : UpdateCursorX;
+      // UpdateAndFullRedraw(FALSE);
+      // UpdateSpritePreview();
       break;
 
     case 3: // CTRL-C
-      Ask("copy sprite to? ", buf, 1);
+      Ask("copy sprite to (0-7)? ", buf, 1);
       if (buf[0] >= '0' && buf[0] <= '7') {
         BYTE toSprite = buf[0] - 48;
         if (SPRITE_SIZE_BYTES(toSprite) == g_state.spriteSizeBytes) {
@@ -1473,10 +1474,11 @@ static void MainLoop()
       break;
 
     case 8: // CTRL-H  (Horz flip)
+      // TODO: implement; issue #78
       break;
 
     case 22: // CTRL-V  (Vert flip)
-
+      // TODO: implement; issue #78
       break;
 
       /* ------------------------------- COLOR GROUP -------------------------- */
@@ -1517,8 +1519,9 @@ static void MainLoop()
       /* ------------------------- DISPLAY GROUP --------------------------------------- */
 
     case 240: // ALT-D
-      setscreensize(80, 50);
-      UpdateAndFullRedraw(FALSE);
+      // TODO: Disabled until we can fix it; issue #74
+      // setscreensize(80, 50);
+      // UpdateAndFullRedraw(FALSE);
       break;
 
     case 174: // ALT-R
@@ -1536,15 +1539,16 @@ static void MainLoop()
       break;
 
     case 0xF5: // F5 LOAD
-      Ask("enter file name to load: ", buf, 19);
+      // TODO: implement
+      // Ask("enter file name to load: ", buf, 19);
       break;
 
     case 0xF7: // F7 SAVE
-      Ask("enter file name to save: ", buf, 19);
-
+      // TODO: implement
+      // Ask("enter file name to save: ", buf, 19);
       break;
 
-    case 0xF9: // Fetch from slot
+    case 0xF9: // F9 Fetch from slot
       UpdateAndFullRedraw(TRUE);
       break;
 

--- a/freeze_sprited.c
+++ b/freeze_sprited.c
@@ -66,13 +66,13 @@
     * Consider SPRBPMEN for 16-color sprites
  */
 #include <cc65.h>
-#include "../mega65-libc/cc65/include/conio.h"
-#include "../mega65-libc/cc65/include/mouse.h"
-#include "../mega65-libc/cc65/include/hal.h"
+#include "./mega65-libc/include/mega65/conio.h"
+#include "./mega65-libc/include/mega65/mouse.h"
+#include "./mega65-libc/include/mega65/hal.h"
 #include <cbm.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include "../mega65-libc/cc65/include/memory.h"
+#include "./mega65-libc/include/mega65/memory.h"
 #include "freezer.h"
 
 extern int errno;


### PR DESCRIPTION
Short-term cosmetic updates to SpritEd:
* Replace descriptions of unimplemented features in Help text with "(not impl)" (#77, #78)
* Disable broken features: xwide (does nothing: #77), 50-line (crashes: #74), load/save (prompts for filename but does nothing; feature needs to wait until we've solved disk images mounted in subdirs)
* Improve the Copy prompt so it's clear that it's a copy to a sprite slot, expecting a number from 0 to 7

This PR also switches to using mega65-libc as a submodule, which is needed because months ago mega65-libc reorg'd and paths have changed. Without the submodule, the build depends on an older unspecified version of mega65-libc being in the parent directory.