### PR TITLE
Set 40 MHz correctly

### DIFF
--- a/freezer.c
+++ b/freezer.c
@@ -163,33 +163,35 @@ unsigned char next_cpu_speed(void)
 {
   switch (detect_cpu_speed()) {
   case 1:
-    // Make it 2MHz
+    // Make it 2MHz: 2MHZ && !FAST && !VFAST
     // ffd0030 is a special register to access the C128 D030.0 bit
     freeze_poke(0xffd0030L, 1);
     freeze_poke(0xffd3031L, freeze_peek(0xffd3031L) & 0xbf);
     freeze_poke(0xffd3054L, freeze_peek(0xffd3054L) & 0xbf);
     return 1;
   case 2:
-    // Make it 3.5MHz
+    // Make it 3.5MHz: !2MHZ && FAST && !VFAST
     freeze_poke(0xffd0030L, 0);
     freeze_poke(0xffd3031L, freeze_peek(0xffd3031L) | 0x40);
     freeze_poke(0xffd3054L, freeze_peek(0xffd3054L) & 0xbf);
     // freeze_poke(0xffd367dL, freeze_peek(0xffd367dL) & 0xef);
     break;
   case 3:
-    // Make it 40MHz
+    // Make it 40MHz: !2MHZ && FAST && VFAST
     freeze_poke(0xffd0030L, 0);
-    freeze_poke(0xffd3031L, freeze_peek(0xffd3031L) & 0xbf);
+    freeze_poke(0xffd3031L, freeze_peek(0xffd3031L) | 0x40);
     freeze_poke(0xffd3054L, freeze_peek(0xffd3054L) | 0x40);
     // freeze_poke(0xffd367dL, freeze_peek(0xffd367dL) | 0x10);
     break;
   case 40:
   default:
-    // Make it 1MHz
+    // Make it 1MHz: !2MHZ && !FAST && !VFAST
     freeze_poke(0xffd0030L, 0);
     freeze_poke(0xffd3031L, freeze_peek(0xffd3031L) & 0xbf);
     freeze_poke(0xffd3054L, freeze_peek(0xffd3054L) & 0xbf);
-    // we clear this, but we don't set it again
+    // If a program forced 40 MHz via POKE 0,65, the Hypervisor flag at
+    // ffd367d is set, and is overriding the other flags. Clear it.
+    // The Freezer itself does not set this.
     freeze_poke(0xffd367dL, freeze_peek(0xffd367dL) & 0xef);
     return 1;
   }

--- a/freezer_common.c
+++ b/freezer_common.c
@@ -176,6 +176,15 @@ char *detect_rom(void)
 
 unsigned char detect_cpu_speed(void)
 {
+  // Technically this is more correct, involving the 2 MHz flag:
+  //   FORCE || (VFAST && (FAST || 2MHZ)) -> 40 MHz
+  //
+  // if ((freeze_peek(0xffd367dL) & 0x10) ||
+  //     (freeze_peek(0xffd3054L) & 0x40) &&
+  //         ((freeze_peek(0xffd3031L) & 0x40) ||
+  //          (freeze_peek(0xffd0030L) & 0x01)))
+  //    return 40;
+
   if (freeze_peek(0xffd367dL) & 0x10)
     return 40;
   if (freeze_peek(0xffd3054L) & 0x40)
@@ -239,14 +248,14 @@ void screen_of_death(char* msg)
 
   // No sprites
   POKE(0xD015U,0x00);
-  
+
   // Normal video mode (but preserve CRT emulation etc)
   POKE(0xD054U,PEEK(0xD054)&0xA8);
 
   // Reset colour palette to normal for black and white
   POKE(0xD100U,0x00);  POKE(0xD200U,0x00);  POKE(0xD300U,0x00);
   POKE(0xD101U,0xFF);  POKE(0xD201U,0xFF);  POKE(0xD301U,0xFF);
-  
+
   POKE(0xD020U,0); POKE(0xD021U,0);
 
   // Reset CPU IO ports


### PR DESCRIPTION
Fixes https://github.com/MEGA65/mega65-freezemenu/issues/87

See discussion: https://github.com/MEGA65/mega65-rom-public/issues/89

I attempted to make the speed detection logic more accurate but I ran out of space for FREEZER.M65. It's an edge case involving the C128 2 MHz flag, so it's not critical. I left a comment about it for future reference, no code change.