### PR TITLE
Allow addresses to be prefixed by any number of spaces

### DIFF
--- a/freeze_monitor.c
+++ b/freeze_monitor.c
@@ -369,6 +369,11 @@ unsigned char parse_hex(void)
       digits++;
       screen_line_offset++;
       break;
+    case ' ': // Allow leading spaces. 
+      if (digits == 0) {
+        screen_line_offset++;
+        break;
+      }
     default:
       return digits;
     }


### PR DESCRIPTION
Without this change  'm00bd' would work correctly while, eg: 'm 00bd' would start at 0000 instead due to parse_address not handling leading spaces. 